### PR TITLE
Dynamic, CGLib and Javassist proxy objects as sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <skip.spotless.scan>false</skip.spotless.scan>
     <spotless-maven-plugin.version>2.17.2</spotless-maven-plugin.version>
+    <javassist.version>3.28.0-GA</javassist.version>
   </properties>
 
   <dependencies>
@@ -67,6 +68,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
       <version>${spring.boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>${javassist.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/com/naharoo/commons/mapstruct/ClassUtils.java
+++ b/src/main/java/com/naharoo/commons/mapstruct/ClassUtils.java
@@ -1,0 +1,62 @@
+package com.naharoo.commons.mapstruct;
+
+import java.lang.reflect.Proxy;
+import javassist.util.proxy.ProxyFactory;
+import org.springframework.core.GenericTypeResolver;
+
+@PrivateApi
+public final class ClassUtils {
+
+    private static final String CGLIB_CLASS_TOKEN = "CGLIB";
+
+    private ClassUtils() {
+        throw new IllegalAccessError("You will not pass!");
+    }
+
+    @PrivateApi
+    public static boolean isProxy(final Class<?> clazz) {
+        return isDynamicProxy(clazz) || isCglibProxy(clazz) || isJavassistProxy(clazz);
+    }
+
+    @PrivateApi
+    public static boolean isDynamicProxy(final Class<?> clazz) {
+        return clazz != null && Proxy.isProxyClass(clazz);
+    }
+
+    @PrivateApi
+    public static boolean isCglibProxy(final Class<?> clazz) {
+        return clazz != null && clazz.getName().contains(CGLIB_CLASS_TOKEN);
+    }
+
+    @PrivateApi
+    public static boolean isJavassistProxy(final Class<?> clazz) {
+        return clazz != null && isClassPresentInClasspath("javassist.util.proxy.ProxyFactory") && ProxyFactory.isProxyClass(clazz);
+    }
+
+    @PrivateApi
+    public static boolean isClassPresentInClasspath(final String fullQualifiedName) {
+        return isClassPresentInClasspath(fullQualifiedName, ClassUtils.class.getClassLoader())
+            || isClassPresentInClasspath(fullQualifiedName, ClassLoader.getSystemClassLoader());
+    }
+
+    @PrivateApi
+    public static boolean isClassPresentInClasspath(final String fullQualifiedName, final ClassLoader loader) {
+        try {
+            Class.forName(fullQualifiedName, false, loader);
+            return true;
+        } catch (final ClassNotFoundException exception) {
+            return false;
+        }
+    }
+
+    @PrivateApi
+    public static Class<?>[] extractGenericParameters(final Class<?> beanClass, final Class<?> genericInterface, final int numberOfParameters) {
+        final Class<?>[] classes = GenericTypeResolver.resolveTypeArguments(beanClass, genericInterface);
+
+        if (classes == null || classes.length < numberOfParameters) {
+            throw new IllegalArgumentException("Failed to extract Generic Parameters from " + beanClass.getName());
+        }
+
+        return classes;
+    }
+}

--- a/src/main/java/com/naharoo/commons/mapstruct/MappingsRegistrationBeanPostProcessor.java
+++ b/src/main/java/com/naharoo/commons/mapstruct/MappingsRegistrationBeanPostProcessor.java
@@ -1,8 +1,9 @@
 package com.naharoo.commons.mapstruct;
 
+import static com.naharoo.commons.mapstruct.ClassUtils.extractGenericParameters;
+
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Primary;
-import org.springframework.core.GenericTypeResolver;
 
 @PrivateApi
 final class MappingsRegistrationBeanPostProcessor implements BeanPostProcessor {
@@ -28,7 +29,7 @@ final class MappingsRegistrationBeanPostProcessor implements BeanPostProcessor {
         final BidirectionalMapper<Object, Object> castedBean = (BidirectionalMapper<Object, Object>) bean;
 
         final Class<?> beanClass = bean.getClass();
-        final Class<?>[] genericClasses = extractGenericParameters(beanClass, BidirectionalMapper.class);
+        final Class<?>[] genericClasses = extractGenericParameters(beanClass, BidirectionalMapper.class, 2);
         final Class<?> source = genericClasses[0];
         final Class<?> destination = genericClasses[1];
 
@@ -45,7 +46,7 @@ final class MappingsRegistrationBeanPostProcessor implements BeanPostProcessor {
         final UnidirectionalMapper<Object, Object> castedBean = (UnidirectionalMapper<Object, Object>) bean;
 
         final Class<?> beanClass = bean.getClass();
-        final Class<?>[] genericClasses = extractGenericParameters(beanClass, UnidirectionalMapper.class);
+        final Class<?>[] genericClasses = extractGenericParameters(beanClass, UnidirectionalMapper.class, 2);
         final Class<?> source = genericClasses[0];
         final Class<?> destination = genericClasses[1];
 
@@ -54,15 +55,5 @@ final class MappingsRegistrationBeanPostProcessor implements BeanPostProcessor {
         if (!MappingsRegistry.exists(directMappingIdentifier) || beanClass.isAnnotationPresent(Primary.class)) {
             MappingsRegistry.register(directMappingIdentifier, castedBean::map);
         }
-    }
-
-    private Class<?>[] extractGenericParameters(final Class<?> beanClass, final Class<?> genericInterface) {
-        final Class<?>[] classes = GenericTypeResolver.resolveTypeArguments(beanClass, genericInterface);
-
-        if (classes == null || classes.length < 2) {
-            throw new IllegalArgumentException("Failed to extract Generic Parameters from " + beanClass.getName());
-        }
-
-        return classes;
     }
 }

--- a/src/main/java/com/naharoo/commons/mapstruct/SimpleMappingFacade.java
+++ b/src/main/java/com/naharoo/commons/mapstruct/SimpleMappingFacade.java
@@ -1,15 +1,19 @@
 package com.naharoo.commons.mapstruct;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StopWatch;
-
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StopWatch;
 
 @PublicApi
 public class SimpleMappingFacade implements MappingFacade {

--- a/src/test/java/com/naharoo/commons/mapstruct/ClassUtilsTest.java
+++ b/src/test/java/com/naharoo/commons/mapstruct/ClassUtilsTest.java
@@ -1,0 +1,186 @@
+package com.naharoo.commons.mapstruct;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+import java.util.UUID;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cglib.proxy.Enhancer;
+import org.springframework.cglib.proxy.InvocationHandler;
+
+@SuppressWarnings("ConstantConditions")
+class ClassUtilsTest {
+
+    @Test
+    @DisplayName("When a non-proxy class is provided, false should be returned")
+    void isProxy() {
+        // Given
+        final Class<?> clazz = Object.class;
+
+        // When
+        final boolean result = ClassUtils.isProxy(clazz);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("When a valid dynamic proxy is provided, true should be returned")
+    void isDynamicProxy() {
+        // Given
+        final Runnable proxy = (Runnable) Proxy.newProxyInstance(
+            this.getClass().getClassLoader(),
+            new Class[] {Runnable.class},
+            (proxyObject, method, args) -> null
+        );
+        final Class<?> clazz = proxy.getClass();
+
+        // When
+        final boolean result = ClassUtils.isDynamicProxy(clazz);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("When a not valid dynamic proxy is provided, false should be returned")
+    void isNotDynamicProxy() {
+        // Given
+        final Class<Object> clazz = Object.class;
+
+        // When
+        final boolean result = ClassUtils.isDynamicProxy(clazz);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("When a valid CGLib proxy is provided, true should be returned")
+    void isCglibProxy() {
+        // Given
+        final Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(Runnable.class);
+        enhancer.setCallback((InvocationHandler) (proxyObject, method, args) -> null);
+        final Runnable proxy = (Runnable) enhancer.create();
+        final Class<?> clazz = proxy.getClass();
+
+        // When
+        final boolean result = ClassUtils.isCglibProxy(clazz);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("When a not valid CGLib proxy is provided, false should be returned")
+    void isNotCglibProxy() {
+        // Given
+        final Class<Object> clazz = Object.class;
+
+        // When
+        final boolean result = ClassUtils.isCglibProxy(clazz);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("When null is provided, false should be returned")
+    void isNotCglibProxyWhenNull() {
+        // Given
+        final Class<Object> clazz = null;
+
+        // When
+        final boolean result = ClassUtils.isCglibProxy(clazz);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("When a valid Javassist proxy is provided, true should be returned")
+    void isJavassistProxy() throws InstantiationException, IllegalAccessException {
+        // Given
+        final ProxyFactory factory = new ProxyFactory();
+        factory.setInterfaces(new Class[] {Runnable.class});
+        final Class<?> clazz = factory.createClass();
+        final Object instance = clazz.newInstance();
+        ((ProxyObject) instance).setHandler((self, method, forwarder, args) -> null);
+
+        // When
+        final boolean result = ClassUtils.isJavassistProxy(clazz);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("When a not valid Javassist proxy is provided, false should be returned")
+    void isNotJavassistProxy() {
+        // Given
+        final Class<Object> clazz = Object.class;
+
+        // When
+        final boolean result = ClassUtils.isJavassistProxy(clazz);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("When null is provided, false should be returned")
+    void isNotJavassistProxyWhenNull() {
+        // Given
+        final Class<Object> clazz = null;
+
+        // When
+        final boolean result = ClassUtils.isJavassistProxy(clazz);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("When existing class name is provided, true should be returned")
+    void isClassPresentInClasspathWhenValidName() {
+        // Given
+        // no initial config
+
+        // When
+        final boolean result = ClassUtils.isClassPresentInClasspath("java.lang.String");
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("When not existing class name is provided, true should be returned")
+    void isClassPresentInClasspathWhenNotValidName() {
+        // Given
+        // no initial config
+
+        // When
+        final boolean result = ClassUtils.isClassPresentInClasspath(UUID.randomUUID().toString());
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("When String class is provided for Comparable generic interface, String class should be returned")
+    void extractGenericParameters() {
+        // Given
+        final Class<String> beanClass = String.class;
+        final Class<?> genericInterface = Comparable.class;
+
+        // When
+        final Class<?>[] genericParameters = ClassUtils.extractGenericParameters(beanClass, genericInterface, 1);
+
+        // Then
+        assertThat(genericParameters).isNotNull().isNotEmpty().contains(String.class);
+    }
+}

--- a/src/test/java/com/naharoo/commons/mapstruct/ProxySourceClassMappingTest.java
+++ b/src/test/java/com/naharoo/commons/mapstruct/ProxySourceClassMappingTest.java
@@ -1,0 +1,174 @@
+package com.naharoo.commons.mapstruct;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.naharoo.commons.mapstruct.mapper.proxies.sourceclass.Laptop;
+import com.naharoo.commons.mapstruct.mapper.proxies.sourceclass.LaptopProxyAbstractClass;
+import com.naharoo.commons.mapstruct.mapper.proxies.sourceclass.LaptopProxyInterface;
+import java.lang.reflect.Proxy;
+import java.util.UUID;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cglib.proxy.Enhancer;
+import org.springframework.cglib.proxy.InvocationHandler;
+import org.springframework.context.annotation.ComponentScan;
+
+@ComponentScan("com.naharoo.commons.mapstruct.mapper.proxies.sourceclass")
+class ProxySourceClassMappingTest extends AbstractMappingTest {
+
+    @Test
+    @DisplayName("When source is a dynamic proxy, S -> D mapping should map all proxy field values")
+    void testDynamicProxySource() {
+        // Given
+        final String brand = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+        final LaptopProxyInterface proxySource = (LaptopProxyInterface) Proxy.newProxyInstance(
+            this.getClass().getClassLoader(),
+            new Class[] {LaptopProxyInterface.class},
+            (proxyObject, method, args) -> {
+                final String methodName = method.getName();
+                if (methodName.equals("getBrand")) {
+                    return brand;
+                }
+                if (methodName.equals("getName")) {
+                    return name;
+                }
+                throw new UnsupportedOperationException("Not supported use-case");
+            }
+        );
+
+        // When
+        final Laptop result = mappingFacade.map(proxySource, Laptop.class);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getBrand()).isEqualTo(brand);
+        assertThat(result.getName()).isEqualTo(name);
+    }
+
+    @Test
+    @DisplayName("When source is a CGLib proxy interface, S -> D mapping should map all proxy field values")
+    void testCGLibProxyInterfaceSource() {
+        // Given
+        final String brand = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+
+        final Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(LaptopProxyInterface.class);
+        enhancer.setCallback((InvocationHandler) (proxyObject, method, args) -> {
+            final String methodName = method.getName();
+            if (methodName.equals("getBrand")) {
+                return brand;
+            }
+            if (methodName.equals("getName")) {
+                return name;
+            }
+            throw new UnsupportedOperationException("Not supported use-case");
+        });
+        final LaptopProxyInterface proxySource = (LaptopProxyInterface) enhancer.create();
+
+        // When
+        final Laptop result = mappingFacade.map(proxySource, Laptop.class);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getBrand()).isEqualTo(brand);
+        assertThat(result.getName()).isEqualTo(name);
+    }
+
+    @Test
+    @DisplayName("When source is a CGLib proxy abstract class, S -> D mapping should map all proxy field values")
+    void testCGLibProxyAbstractClassSource() {
+        // Given
+        final String brand = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+
+        final Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(LaptopProxyAbstractClass.class);
+        enhancer.setCallback((InvocationHandler) (proxyObject, method, args) -> {
+            final String methodName = method.getName();
+            if (methodName.equals("getBrand")) {
+                return brand;
+            }
+            if (methodName.equals("getName")) {
+                return name;
+            }
+            throw new UnsupportedOperationException("Not supported use-case");
+        });
+        final LaptopProxyAbstractClass proxySource = (LaptopProxyAbstractClass) enhancer.create();
+
+        // When
+        final Laptop result = mappingFacade.map(proxySource, Laptop.class);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getBrand()).isEqualTo(brand);
+        assertThat(result.getName()).isEqualTo(name);
+    }
+
+    @Test
+    @DisplayName("When source is a Javassist proxy interface, S -> D mapping should map all proxy field values")
+    void testJavassistProxyInterfaceSource() throws InstantiationException, IllegalAccessException {
+        // Given
+        final String brand = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+
+        final ProxyFactory factory = new ProxyFactory();
+        factory.setInterfaces(new Class[] {LaptopProxyInterface.class});
+        final Class<?> clazz = factory.createClass();
+        final Object instance = clazz.newInstance();
+        ((ProxyObject) instance).setHandler((self, method, forwarder, args) -> {
+            final String methodName = method.getName();
+            if (methodName.equals("getBrand")) {
+                return brand;
+            }
+            if (methodName.equals("getName")) {
+                return name;
+            }
+            throw new UnsupportedOperationException("Not supported use-case");
+        });
+        final LaptopProxyInterface proxySource = (LaptopProxyInterface) instance;
+
+        // When
+        final Laptop result = mappingFacade.map(proxySource, Laptop.class);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getBrand()).isEqualTo(brand);
+        assertThat(result.getName()).isEqualTo(name);
+    }
+
+    @Test
+    @DisplayName("When source is a Javassist proxy abstract class, S -> D mapping should map all proxy field values")
+    void testJavassistProxyAbstractClassSource() throws InstantiationException, IllegalAccessException {
+        // Given
+        final String brand = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+
+        final ProxyFactory factory = new ProxyFactory();
+        factory.setSuperclass(LaptopProxyAbstractClass.class);
+        final Class<?> clazz = factory.createClass();
+        final Object instance = clazz.newInstance();
+        ((ProxyObject) instance).setHandler((self, method, forwarder, args) -> {
+            final String methodName = method.getName();
+            if (methodName.equals("getBrand")) {
+                return brand;
+            }
+            if (methodName.equals("getName")) {
+                return name;
+            }
+            throw new UnsupportedOperationException("Not supported use-case");
+        });
+        final LaptopProxyAbstractClass proxySource = (LaptopProxyAbstractClass) instance;
+
+        // When
+        final Laptop result = mappingFacade.map(proxySource, Laptop.class);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getBrand()).isEqualTo(brand);
+        assertThat(result.getName()).isEqualTo(name);
+    }
+}

--- a/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/Laptop.java
+++ b/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/Laptop.java
@@ -1,0 +1,20 @@
+package com.naharoo.commons.mapstruct.mapper.proxies.sourceclass;
+
+public class Laptop {
+
+    private final String brand;
+    private final String name;
+
+    public Laptop(final String brand, final String name) {
+        this.brand = brand;
+        this.name = name;
+    }
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/LaptopProxyAbstractClass.java
+++ b/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/LaptopProxyAbstractClass.java
@@ -1,0 +1,8 @@
+package com.naharoo.commons.mapstruct.mapper.proxies.sourceclass;
+
+public abstract class LaptopProxyAbstractClass {
+
+    public abstract String getBrand();
+
+    public abstract String getName();
+}

--- a/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/LaptopProxyAbstractClassMapper.java
+++ b/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/LaptopProxyAbstractClassMapper.java
@@ -1,0 +1,9 @@
+package com.naharoo.commons.mapstruct.mapper.proxies.sourceclass;
+
+import static com.naharoo.commons.mapstruct.Mapper.SPRING_COMPONENT_MODEL;
+
+import com.naharoo.commons.mapstruct.UnidirectionalMapper;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = SPRING_COMPONENT_MODEL)
+public interface LaptopProxyAbstractClassMapper extends UnidirectionalMapper<LaptopProxyAbstractClass, Laptop> {}

--- a/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/LaptopProxyInterface.java
+++ b/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/LaptopProxyInterface.java
@@ -1,0 +1,7 @@
+package com.naharoo.commons.mapstruct.mapper.proxies.sourceclass;
+
+public interface LaptopProxyInterface {
+    String getBrand();
+
+    String getName();
+}

--- a/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/LaptopProxyInterfaceMapper.java
+++ b/src/test/java/com/naharoo/commons/mapstruct/mapper/proxies/sourceclass/LaptopProxyInterfaceMapper.java
@@ -1,0 +1,9 @@
+package com.naharoo.commons.mapstruct.mapper.proxies.sourceclass;
+
+import static com.naharoo.commons.mapstruct.Mapper.SPRING_COMPONENT_MODEL;
+
+import com.naharoo.commons.mapstruct.UnidirectionalMapper;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = SPRING_COMPONENT_MODEL)
+public interface LaptopProxyInterfaceMapper extends UnidirectionalMapper<LaptopProxyInterface, Laptop> {}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -2,6 +2,5 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
 
-
     <logger name="com.naharoo.commons.mapstruct" level="TRACE"/>
 </configuration>


### PR DESCRIPTION
This PR contains changes to support Dynamic, CGLib and Javassist proxy objects as sources for the MappingFacade.
Possible successor of https://github.com/naharoo/mapstruct-facade-spring-boot-starter/pull/4