### PR TITLE
Hibernate proxies as sources support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <skip.spotless.scan>false</skip.spotless.scan>
     <spotless-maven-plugin.version>2.17.2</spotless-maven-plugin.version>
     <javassist.version>3.28.0-GA</javassist.version>
+    <hibernate.version>5.6.7.Final</hibernate.version>
   </properties>
 
   <dependencies>
@@ -72,6 +73,12 @@
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
       <version>${javassist.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>${hibernate.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/com/naharoo/commons/mapstruct/ClassUtils.java
+++ b/src/main/java/com/naharoo/commons/mapstruct/ClassUtils.java
@@ -2,6 +2,7 @@ package com.naharoo.commons.mapstruct;
 
 import java.lang.reflect.Proxy;
 import javassist.util.proxy.ProxyFactory;
+import org.hibernate.proxy.HibernateProxy;
 import org.springframework.core.GenericTypeResolver;
 
 @PrivateApi
@@ -15,7 +16,7 @@ public final class ClassUtils {
 
     @PrivateApi
     public static boolean isProxy(final Class<?> clazz) {
-        return isDynamicProxy(clazz) || isCglibProxy(clazz) || isJavassistProxy(clazz);
+        return isDynamicProxy(clazz) || isCglibProxy(clazz) || isJavassistProxy(clazz) || isHibernateProxy(clazz);
     }
 
     @PrivateApi
@@ -31,6 +32,11 @@ public final class ClassUtils {
     @PrivateApi
     public static boolean isJavassistProxy(final Class<?> clazz) {
         return clazz != null && isClassPresentInClasspath("javassist.util.proxy.ProxyFactory") && ProxyFactory.isProxyClass(clazz);
+    }
+
+    @PrivateApi
+    public static boolean isHibernateProxy(final Class<?> clazz) {
+        return clazz != null && isClassPresentInClasspath("org.hibernate.proxy.HibernateProxy") && HibernateProxy.class.isAssignableFrom(clazz);
     }
 
     @PrivateApi

--- a/src/main/java/com/naharoo/commons/mapstruct/MappingsRegistry.java
+++ b/src/main/java/com/naharoo/commons/mapstruct/MappingsRegistry.java
@@ -100,7 +100,8 @@ public final class MappingsRegistry {
         }
 
         // If the source class is a Proxy, we need to traverse and check parents tree
-        // Here we're checking the superclass, mainly for CGLib Proxies
+        // Here we're checking the superclass
+        // Used for CGLib and Hibernate proxies
         final Class<?> sourceSuperclass = sourceClass.getSuperclass();
         if (sourceSuperclass != null) {
             final Optional<UnaryOperator<Object>> mappingFunctionOpt = findMappingFunction(sourceSuperclass, destinationClass);
@@ -109,7 +110,8 @@ public final class MappingsRegistry {
             }
         }
 
-        // Here we're checking superinterfaces, mainly for Dynamic Proxies
+        // Here we're checking superinterfaces
+        // Used for Dynamic and Javassist proxies
         final Class<?>[] sourceInterfaces = sourceClass.getInterfaces();
         for (final Class<?> sourceInterface : sourceInterfaces) {
             final Optional<UnaryOperator<Object>> mappingFunctionOpt = findMappingFunction(


### PR DESCRIPTION
Added support for Hibernate proxy objects as sources.

Seems like Hibernate implements it's proxies from HibernateProxy inteface and we can use this as a criteria for finding our "broken" cases.

When we encounter a hibernate proxy, we'll try to traverse the hierarchy tree above to find the next superclass. That superclass will be the one we have registered a mapping for.

e.g.


```
@Mapper
interface LocationMapper extends UnidirectionalMapper<Location, LocationDto> {}
```


```
Location            HibernateProxy
   ^                      ^
   |                      |
   |                      |
   |                      |
   |                      |
 ProxyClassGeneratedByHibernate (our candidate)
```
